### PR TITLE
Support for Nested Property Validation

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -104,11 +104,8 @@ Validator.prototype.equals = function(other, message) {
   return this.add(function(value) {
     // If other is a field token (field::fieldname), grab the value of fieldname
     // and use that as the OTHER value.
-    console.log("VALUE:",value);
-    console.log("OTHER:",other);
     if (object.isString(other) && other.match(/^field::/)) {
       other = arguments.callee.getValue(other.replace(/^field::/, ''));
-      console.log("OTHER2:",other);
     }
     if (value != other) {
       throw new Error(message || "%s does not equal " + String(other));

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -25,13 +25,14 @@ function Validator(fieldname, label) {
 
     stack.forEach(function(validate) {
       validate.getValue = function(name) {
-        return formData[name];
+        var match = name.match(/^([^\[]*)(?:\[(.*)\])*$/);
+        var value = formData[match[1] || name];
+        if(match.length > 2) { // if complex property (e.g. user[info][password])
+          for(var mi = 2, mval; mval = match[mi]; mi++) value = value[mval];
+        }
+        return value;
       };
-      var match = fieldname.match(/^([^\[]*)(?:\[(.*)\])*$/);
-      var value = formData[match[1] || fieldname];
-      if(match.length > 2) { // if complex property (e.g. user[info][password])
-        for(var mi = 2, mval; mval = match[mi]; mi++) value = value[mval];
-      }
+      var value = validate.getValue(fieldname);
       
       if (false === this.__required && false === hasValue(value)) {
         // If this field is not required and it doesn't have a value,
@@ -103,8 +104,11 @@ Validator.prototype.equals = function(other, message) {
   return this.add(function(value) {
     // If other is a field token (field::fieldname), grab the value of fieldname
     // and use that as the OTHER value.
+    console.log("VALUE:",value);
+    console.log("OTHER:",other);
     if (object.isString(other) && other.match(/^field::/)) {
       other = arguments.callee.getValue(other.replace(/^field::/, ''));
+      console.log("OTHER2:",other);
     }
     if (value != other) {
       throw new Error(message || "%s does not equal " + String(other));

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -27,8 +27,11 @@ function Validator(fieldname, label) {
       validate.getValue = function(name) {
         return formData[name];
       };
-      
-      var value = formData[fieldname];
+      var match = fieldname.match(/^([^\[]*)(?:\[(.*)\])*$/);
+      var value = formData[match[1] || fieldname];
+      if(match.length > 2) { // if complex property (e.g. user[info][password])
+        for(var mi = 2, mval; mval = match[mi]; mi++) value = value[mval];
+      }
       
       if (false === this.__required && false === hasValue(value)) {
         // If this field is not required and it doesn't have a value,

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -515,5 +515,11 @@ module.exports = {
     form()(request, {});
     assert.equal(request.form.errors.length, 0);
     assert.equal('{}', JSON.stringify(request.form));
+  },
+
+  "validation : complex properties": function() {
+    var request = { body: { field: { inner: "value" }}};
+    form(validate("field[inner]").required())(request, {});
+    assert.equal(request.form.errors.length, 0);
   }
 };


### PR DESCRIPTION
Right now properties like:
    user[password]
    user[accountInfo][email]

Are throwing an error when trying to validate because they parsed in express as:
    { user: { password: 'value' }}
    { user: { accountInfo: { email: 'value' }}}

This patch allows for these types of properties to correctly validate.  Test also written.
