### PR TITLE
res.locals changed in express 2.0

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -50,7 +50,11 @@ function form() {
             // Make all params locals, so they're accessible from the view.
             // If they have dashes in their names, camelize them so they don't
             // break ejs: <%= field-name %> becomes <%= fieldName %> in your views.
-            res.locals[camelize(name)] = req[source][name];
+            if (typeof res.locals == 'function') { // Express 2.0 Support
+                res.local(camelize(name),req[source][name]);
+            } else {
+                res.locals[camelize(name)] = req[source][name];
+            }
           }
 
           // Copy data as is from source to the form object.

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -25,10 +25,12 @@ function Validator(fieldname, label) {
 
     stack.forEach(function(validate) {
       validate.getValue = function(name) {
-        var match = name.match(/^([^\[]*)(?:\[(.*)\])*$/);
-        var value = formData[match[1] || name];
-        if(match.length > 2) { // if complex property (e.g. user[info][password])
-          for(var mi = 2, mval; mval = match[mi]; mi++) value = value[mval];
+        var match = name.match(/[^\[\]]*/g).filter(function(m){ return !!m; })
+        var value = formData[match[0] || name];
+        if(match.length > 1) { // if complex property (e.g. user[info][password])
+          for(var mi = 1, mval; mval = match[mi]; mi++){
+            value = value[mval];
+          }
         }
         return value;
       };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -106,11 +106,12 @@ Validator.prototype.equals = function(other, message) {
   return this.add(function(value) {
     // If other is a field token (field::fieldname), grab the value of fieldname
     // and use that as the OTHER value.
+    var test = other;
     if (object.isString(other) && other.match(/^field::/)) {
-      other = arguments.callee.getValue(other.replace(/^field::/, ''));
+      test = arguments.callee.getValue(other.replace(/^field::/, ''));
     }
-    if (value != other) {
-      throw new Error(message || "%s does not equal " + String(other));
+    if (value != test) {
+      throw new Error(message || "%s does not equal " + String(test));
     }
   });
 };

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -518,11 +518,13 @@ module.exports = {
   },
 
   "validation : complex properties": function() {
-    var request = { body: { field: { inner: "value" }}};
+    var request = { body: { field: { inner: "value", even: { more: { inner: "value" }}}}};
     form(
       validate("field[inner]").required().equals("value"),
-      validate("field[inner]").required().equals("fail")
+      validate("field[inner]").required().equals("fail"),
+      validate("field[even][more][inner]").required().equals("value"),
+      validate("field[even][more][inner]").required().equals("fail")
     )(request, {});
-    assert.equal(request.form.errors.length, 1);
+    assert.equal(request.form.errors.length, 2);
   }
 };


### PR DESCRIPTION
In Express 2.0, res.locals is now a function that you can assign an object to.  So this broke the ability to get autoLocals pre-populated for 2.0.  This commit checks for that functionality and uses res.local(name,val) if this is the case, otherwise uses existing code for Express 1.0.
