### PR TITLE
Label was not being preferred over the property name

### DIFF
--- a/lib/field.js
+++ b/lib/field.js
@@ -9,7 +9,7 @@ var validator = require("validator")
 function Field(property, label) {
   var stack = []
     , isArray = false
-    , fieldLabel = property || label;
+    , fieldLabel = label || property;
 
   this.name = property;
   this.__required = false;


### PR DESCRIPTION
Label was not being preferred over the property name when used in error messages, saw this in another commit, thought I'd pass it back to get it in the main code base.
