### PR TITLE
add isDate validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Use "%s" in the message to have the field name or label printed in the message:
 
 *By Format*
 
+    isDate([message])
+
     isEmail([message])
 
     isUrl([message])

--- a/lib/field.js
+++ b/lib/field.js
@@ -166,6 +166,7 @@ Field.prototype.customFilter = function (func) {
 // VALIDATE METHODS
 
 var MESSAGES = {
+  isDate: "%s is not a date",
   isEmail: "%s is not an email address",
   isUrl: "%s is not a URL",
   isIP: "%s is not an IP address",

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -3,6 +3,30 @@ var assert = require("assert"),
     validate = form.validate;
 
 module.exports = {
+  'validate : isDate': function() {
+    // Skip validating empty values
+    var request = { body: {} };
+    form(validate("field").isDate())(request, {});
+    assert.equal(request.form.errors.length, 0);
+
+    // Failure.
+    var request = { body: { field: "fail" }};
+    form(validate("field").isDate())(request, {});
+    assert.equal(request.form.errors.length, 1);
+    assert.equal(request.form.errors[0], "field is not a date");
+
+    // Failure w/ custom message.
+    var request = { body: { field: "fail" }};
+    form(validate("field").isDate("!!! %s !!!"))(request, {});
+    assert.equal(request.form.errors.length, 1);
+    assert.equal(request.form.errors[0], "!!! field !!!");
+
+    // Success
+    var request = { body: { field: "01/29/2012" }};
+    form(validate("field").isDate())(request, {});
+    assert.equal(request.form.errors.length, 0);
+  },
+
   'validate : isEmail': function() {
     // Skip validating empty values
     var request = { body: {} };


### PR DESCRIPTION
I'm using express-form and I found that this is a validator I need. Adding support is easy since it's already a part of node-validator.

I added tests as well, but I can't verify that they work since something else is, as far as I can tell, breaking the test runner.

I get the following (using 'nodeunit' is just a guess, I'm new to node and have no idea what to run tests with):

```
spang@sencha:~/src/express-form> nodeunit test/form.test.js

form.test.js
✖ form : isValid

AssertionError: 'Missing expected exception..' undefined undefined
    at Function._throws (assert.js:301:5)
    at Function.throws (assert.js:318:11)
    at Object.<anonymous> (/home/spang/src/express-form/test/form.test.js:17:20)
    at Object.<anonymous> (/usr/local/lib/nodejs/nodeunit/lib/core.js:233:16)
    at /usr/local/lib/nodejs/nodeunit/lib/core.js:233:16
    at Object.runTest (/usr/local/lib/nodejs/nodeunit/lib/core.js:69:9)
    at /usr/local/lib/nodejs/nodeunit/lib/core.js:115:25
    at /usr/local/lib/nodejs/nodeunit/deps/async.js:508:13
    at /usr/local/lib/nodejs/nodeunit/deps/async.js:118:13
    at /usr/local/lib/nodejs/nodeunit/deps/async.js:134:9


FAILURES: Undone tests (or their setups/teardowns): 
- form : getErrors
```
