### PR TITLE
Express 3.0 Support

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -28,8 +28,10 @@ function form() {
       for (var prop in req.body) {
         if (!req.body.hasOwnProperty(prop)) continue;
         
-        if (typeof res.locals === "function") { // Express 2.0 Support
+        if (res.local && typeof res.locals === "function") { // Express 2.0 Support
           res.local(utils.camelize(prop), req.body[prop]);
+        } else if (typeof res.locals === "function") { // Express 3.0
+          res.locals(utils.camelize(prop), req.body[prop]);
         } else {
           if (!res.locals) res.locals = {};
           res.locals[utils.camelize(prop)] = req.body[prop];


### PR DESCRIPTION
I updated express-form for use in express 3.0.  In its current form, the following would be thrown:

TypeError: Object #<ServerResponse> has no method 'local'
