### PR TITLE
Recent versions of the validator module break compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "keywords" : ["form", "validator", "validation", "express"],
   "dependencies": {
-    "validator": ">= 0.1.2",
+    "validator": "~0.1.9",
     "object-additions": ">= 0.5.0"
   },
   "main" : "index",


### PR DESCRIPTION
package.json should lock in compatible version. validator on npm is currently on version 3.x.x.
