### PR TITLE
req.body does not have method hasOwnProperty: Fix

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -26,7 +26,7 @@ function form() {
     
     if (options.autoLocals) {
       for (var prop in req.body) {
-        if (!req.body.hasOwnProperty(prop)) continue;
+        if (!Object.prototype.hasOwnProperty.call(req.body, prop)) continue;
         
         if (typeof res.locals === "function") { // Express 2.0 Support
           res.local(utils.camelize(prop), req.body[prop]);


### PR DESCRIPTION
Fixes an error that is occuring on modern stacks: req.body does not have a method called hasOwnProperty;  I think this is because sometimes the value coming back is an array not an object, and so this fix resolves that.
